### PR TITLE
Allow text or html format

### DIFF
--- a/Src/NLog.HipChat/HipChatTarget.cs
+++ b/Src/NLog.HipChat/HipChatTarget.cs
@@ -30,6 +30,9 @@ namespace NLog.Targets.HipChat
         [DefaultValue(HipChatClient.BackgroundColor.yellow)]
         public HipChatClient.BackgroundColor BackgroundColor { get; set; }
 
+        [DefaultValue("html")]
+        public string MessageFormat { get; set; }
+
 
         protected override void Write(LogEventInfo logEvent)
         {
@@ -38,9 +41,20 @@ namespace NLog.Targets.HipChat
             this.SendMessageToHipchat(log);
         }
 
+        private HipChatClient.MessageFormat ParseFormat()
+        {
+            var ishtml = string.Equals(MessageFormat, "html", StringComparison.OrdinalIgnoreCase);
+            return ishtml
+                ? HipChatClient.MessageFormat.html
+                : HipChatClient.MessageFormat.text;
+        }
+
         private void SendMessageToHipchat(string message)
         {
-            var client = new HipChatClient(this.AuthToken, this.RoomId, this.SenderName);
+            var format = ParseFormat();
+
+            var client = new HipChatClient(this.AuthToken, this.RoomId, format);
+            client.From = SenderName;
 
             client.SendMessage(message, this.BackgroundColor);
         }

--- a/Src/NLog.HipChat/HipChatTarget.cs
+++ b/Src/NLog.HipChat/HipChatTarget.cs
@@ -43,10 +43,10 @@ namespace NLog.Targets.HipChat
 
         private HipChatClient.MessageFormat ParseFormat()
         {
-            var ishtml = string.Equals(MessageFormat, "html", StringComparison.OrdinalIgnoreCase);
-            return ishtml
-                ? HipChatClient.MessageFormat.html
-                : HipChatClient.MessageFormat.text;
+            var isText = string.Equals(MessageFormat, "text", StringComparison.OrdinalIgnoreCase);
+            return isText
+                ? HipChatClient.MessageFormat.text
+                : HipChatClient.MessageFormat.html;
         }
 
         private void SendMessageToHipchat(string message)


### PR DESCRIPTION
Allow MessageFormat to be set.
we need to set the format to "text" in some cases
as this allow us to use at-mentions in the message.
The only option before was "html", this should still be the default. See: https://github.com/hugorodgerbrown/HipChat.net/blob/master/HipChatClient/HipChatClient.cs#L29